### PR TITLE
fix: hide out side days

### DIFF
--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -121,6 +121,9 @@ class _CalendarState extends State<Calendar> {
                   rightChevronIcon: _rightChevron,
                   titleCentered: true,
                 ),
+                calendarStyle: const CalendarStyle(
+                  outsideDaysVisible: false,
+                ),
                 calendarBuilders: CalendarBuilders(
                   defaultBuilder: (context, day, focusedDay) {
                     // NOTE: defaultの日付が出てしまうため


### PR DESCRIPTION
#96 の対応

本来は`CalendarBulders`内の[outsideBuilder](https://pub.dev/documentation/table_calendar/latest/table_calendar/CalendarBuilders/outsideBuilder.html)のオプションで修正できるはずが、return値変えたり、他のオプションを模索したりしたが、変わらずだったので、CalendarStyle内で重複を消すのではなく、非表示にする対応をとりました。

[実装結果]
![Screenshot 2024-03-05 at 18 57 50](https://github.com/codeforjapan/Gussuri/assets/26044110/5e169feb-1cf7-45ce-a18a-8484c7626826)

[参考]
https://stackoverflow.com/questions/74125184/how-to-hide-past-and-next-month-date-in-flutter-tablecalendar
