### PR TITLE
Fix/#108 btn

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -99,7 +99,10 @@ class _HomeState extends State<Home> {
               children: [
                 Container(
                     padding: EdgeInsets.all(30.h),
-                    child: ElevatedButton(
+                    child: _checkLastNightSleep == true ? const Text('睡眠記録の入力は終了しております', style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),) : ElevatedButton(
                       style: ElevatedButton.styleFrom(
                           minimumSize: Size(280.w, 80.h),
                           backgroundColor: const Color(0xffFFD069),
@@ -118,7 +121,8 @@ class _HomeState extends State<Home> {
                             }
                           : null,
                       child: const Text('睡眠記録'),
-                    )),
+                    )
+                ),
                 Container(
                     padding: EdgeInsets.symmetric(vertical: 0.h),
                     child: ElevatedButton.icon(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ class Gussuri extends StatelessWidget {
             title: 'Gussuri',
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
+            debugShowCheckedModeBanner: false,
             home: Base(),
           );
         });


### PR DESCRIPTION
close #108 
[実装内容]
・記入済みの場合、ボタンを非表示にして文言を表示。
・ついでに、simulator開いた際にdebugのリボンが右上に出ていたので消した。
参照：https://www.repeato.app/remove-debug-banner-flutter/

[実装結果]
![simulator_screenshot_E4812ECE-94A4-4138-986C-782E7D64B673](https://github.com/codeforjapan/Gussuri/assets/26044110/38d1515c-4b3e-46bb-a6e3-0e9387daf5c3)
