### PR TITLE
fix: control timer picker state

### DIFF
--- a/lib/component/TimePicker.dart
+++ b/lib/component/TimePicker.dart
@@ -24,7 +24,7 @@ class TimePickerState extends State<TimePickerWidget> {
 
   void _onDateTimeChanged(DateTime dt) {
     if (_debounce?.isActive ?? false) _debounce!.cancel();
-    _debounce = Timer(const Duration(milliseconds: 500), () {
+    _debounce = Timer(const Duration(milliseconds: 200), () {
       setState(() {
         dateTime = dt;
         if (widget.onChanged != null) {
@@ -32,6 +32,11 @@ class TimePickerState extends State<TimePickerWidget> {
         }
       });
     });
+  }
+
+  void finalizeChanges() {
+    _debounce?.cancel();
+    widget.onChanged?.call(dateTime.toString());
   }
 
   @override

--- a/lib/component/TimePicker.dart
+++ b/lib/component/TimePicker.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'dart:async';
 
 class TimePickerWidget extends StatefulWidget {
   final DateTime value;
@@ -11,34 +12,47 @@ class TimePickerWidget extends StatefulWidget {
 }
 
 class TimePickerState extends State<TimePickerWidget> {
-  dynamic dateTime;
-  late final ValueChanged<String?> submitOnChanged;
+
+  late DateTime dateTime;
+  Timer? _debounce;
 
   @override
   void initState() {
     super.initState();
-    if(widget.onChanged != null) {
-      submitOnChanged = widget.onChanged!;
-    }
     dateTime = widget.value;
+  }
+
+  void _onDateTimeChanged(DateTime dt) {
+    if (_debounce?.isActive ?? false) _debounce!.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), () {
+      setState(() {
+        dateTime = dt;
+        if (widget.onChanged != null) {
+          widget.onChanged!(dt.toString());
+        }
+      });
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-        height: 100,
+        height: 150,
         width: 300,
         child: CupertinoDatePicker(
           key: UniqueKey(),
           backgroundColor: Colors.white,
           mode: CupertinoDatePickerMode.time,
           initialDateTime: dateTime,
-          onDateTimeChanged: (dt) {
-            setState(() => dateTime = dt);
-            submitOnChanged(dt.toString());
-          },
+          onDateTimeChanged: _onDateTimeChanged,
           use24hFormat: true,
           minuteInterval: 1,
         ));
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
   }
 }

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -153,6 +153,7 @@ class _EditState extends State<Edit> {
                         buttonText: '編集保存',
                         onPressed: _checkSubmit()
                             ? () {
+                                GlobalObjectKey<TimePickerState>(uuid.v4()).currentState?.finalizeChanges();
                                 _updateSleepyData();
                               }
                             : null,

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -184,6 +184,8 @@ class _InputState extends State<Input> {
                         buttonText: '入力完了',
                         onPressed: _checkSubmit()
                             ? () {
+                                  timePickerKey.currentState?.finalizeChanges();
+                                  timePickerKeySecond.currentState?.finalizeChanges();
                                 _createSleepyData();
                               }
                             : null,


### PR DESCRIPTION
close https://github.com/codeforjapan/Gussuri/issues/115

[原因]
ユーザーが時間を変更する操作をするたびにonDateTimeChanged内でsetStateがトリガーされるので、選択された時間のstateの更新がおき、uiの再描画が頻繁に起きていたのが原因。

[対応]
debounceを適用して、ユーザーの操作とstateの更新タイミングを同期的に行われないようにした。Timerを使ってユーザーの操作が終わった500ミリ秒後にstateの更新を入れてみた。ほぼ一瞬に近いので問題ないとは思う。
あと、ついでに縦幅も広げてみた

[実装結果]
https://github.com/codeforjapan/Gussuri/assets/26044110/e180d2ee-de10-4bd6-89d0-1ea3c0830d97

[参考記事]
https://www.dhiwise.com/post/flutter-performance-a-deep-dive-into-debounce-mechanism

