### PR TITLE
feat: タブレット UI 対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ lib_copy/
 .fvm/flutter_sdk
 .fvm/versions/
 # .fvm/fvm_config.json はトラッキング対象（チームで SDK バージョンを共有するため）
+.superpowers/

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
-
-    <!-- You can insert your own images assets here -->
-    <!-- <item>
+    <item android:drawable="@color/splash_background" />
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
-
-    <!-- You can insert your own images assets here -->
-    <!-- <item>
+    <item android:drawable="@color/splash_background" />
+    <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+            android:src="@mipmap/ic_launcher" />
+    </item>
 </layer-list>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#FFF0C7</color>
+</resources>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1272,6 +1272,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_pdfview (1.0.2):
     - Flutter
+  - flutter_secure_storage (6.0.0):
+    - Flutter
   - fluttertoast (0.0.2):
     - Flutter
   - GoogleDataTransport (10.1.0):
@@ -1392,6 +1394,11 @@ PODS:
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
+  - share_plus (0.0.1):
+    - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -1402,8 +1409,11 @@ DEPENDENCIES:
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
   - flutter_pdfview (from `.symlinks/plugins/flutter_pdfview/ios`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -1444,10 +1454,16 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_pdfview:
     :path: ".symlinks/plugins/flutter_pdfview/ios"
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -1472,6 +1488,7 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 76bdd9de8ff1da7a601236ee058253e36206978e
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_pdfview: 2e4d13ffb774858562ffbdfdb61b40744b191adc
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -1482,6 +1499,8 @@ SPEC CHECKSUMS:
   path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
   url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: 389f6eed18471ca2f4178020e74c037903e817e2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -595,7 +595,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -631,7 +631,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -109,7 +109,7 @@ class _AboutMeState extends State<AboutMe> with SingleTickerProviderStateMixin {
             child: SafeArea(
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 560),
+                  constraints: const BoxConstraints(maxWidth: 700),
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(28, 0, 28, 28),
                     child: Row(

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -323,11 +323,8 @@ class _MoonIllustration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(
-      Icons.nightlight_round,
-      size: 140.w,
-      color: Colors.white.withValues(alpha: 0.9),
-    );
+    final s = (MediaQuery.of(context).size.shortestSide * 0.35).clamp(100.0, 190.0);
+    return Icon(Icons.nightlight_round, size: s, color: Colors.white.withValues(alpha: 0.9));
   }
 }
 
@@ -337,7 +334,7 @@ class _TimeSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final shortestSide = MediaQuery.of(context).size.shortestSide;
-    final imgSize = (shortestSide / 360 * 48).clamp(48.0, 80.0);
+    final imgSize = (shortestSide / 360 * 48).clamp(48.0, 96.0);
     final hPad = (shortestSide / 360 * 6).clamp(6.0, 10.0);
 
     return FittedBox(
@@ -364,11 +361,8 @@ class _CalendarIllustration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(
-      Icons.calendar_month,
-      size: 130.w,
-      color: Colors.white.withValues(alpha: 0.9),
-    );
+    final s = (MediaQuery.of(context).size.shortestSide * 0.33).clamp(100.0, 180.0);
+    return Icon(Icons.calendar_month, size: s, color: Colors.white.withValues(alpha: 0.9));
   }
 }
 
@@ -377,10 +371,7 @@ class _ExportIllustration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(
-      Icons.file_download_outlined,
-      size: 130.w,
-      color: Colors.white.withValues(alpha: 0.9),
-    );
+    final s = (MediaQuery.of(context).size.shortestSide * 0.33).clamp(100.0, 180.0);
+    return Icon(Icons.file_download_outlined, size: s, color: Colors.white.withValues(alpha: 0.9));
   }
 }

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -107,40 +107,45 @@ class _AboutMeState extends State<AboutMe> with SingleTickerProviderStateMixin {
             left: 0,
             right: 0,
             child: SafeArea(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(28.w, 0, 28.w, 28.h),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    _DotIndicator(
-                      total: _totalPages,
-                      current: _currentPage,
-                      onTap: (i) => _pageController.animateToPage(
-                        i,
-                        duration: const Duration(milliseconds: 350),
-                        curve: Curves.easeInOut,
-                      ),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 560),
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(28, 0, 28, 28),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _DotIndicator(
+                          total: _totalPages,
+                          current: _currentPage,
+                          onTap: (i) => _pageController.animateToPage(
+                            i,
+                            duration: const Duration(milliseconds: 350),
+                            curve: Curves.easeInOut,
+                          ),
+                        ),
+                        ElevatedButton(
+                          onPressed: _next,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.white,
+                            foregroundColor: const Color(0xFF002153),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 28,
+                              vertical: 14,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(50),
+                            ),
+                            textStyle: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          child: Text(isLast ? l.aboutMeDone : l.aboutMeNext),
+                        ),
+                      ],
                     ),
-                    ElevatedButton(
-                      onPressed: _next,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.white,
-                        foregroundColor: const Color(0xFF002153),
-                        padding: EdgeInsets.symmetric(
-                          horizontal: 28.w,
-                          vertical: 14.h,
-                        ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(50),
-                        ),
-                        textStyle: TextStyle(
-                          fontSize: 16.sp,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      child: Text(isLast ? l.aboutMeDone : l.aboutMeNext),
-                    ),
-                  ],
+                  ),
                 ),
               ),
             ),

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -280,13 +280,17 @@ class _EvaluationSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final shortestSide = MediaQuery.of(context).size.shortestSide;
+    final imgSize = (shortestSide / 360 * 54).clamp(54.0, 88.0);
+    final hPad = (shortestSide / 360 * 6).clamp(6.0, 10.0);
+
     return FittedBox(
       fit: BoxFit.scaleDown,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [0, 3, 5, 7, 10].map((i) {
           return Padding(
-            padding: EdgeInsets.symmetric(horizontal: 6.w),
+            padding: EdgeInsets.symmetric(horizontal: hPad),
             child: Container(
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
@@ -301,8 +305,8 @@ class _EvaluationSample extends StatelessWidget {
               child: ClipOval(
                 child: Image.asset(
                   'images/evaluation_$i.jpg',
-                  width: 54.w,
-                  height: 54.w,
+                  width: imgSize,
+                  height: imgSize,
                   fit: BoxFit.cover,
                 ),
               ),
@@ -332,17 +336,21 @@ class _TimeSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final shortestSide = MediaQuery.of(context).size.shortestSide;
+    final imgSize = (shortestSide / 360 * 48).clamp(48.0, 80.0);
+    final hPad = (shortestSide / 360 * 6).clamp(6.0, 10.0);
+
     return FittedBox(
       fit: BoxFit.scaleDown,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: List.generate(5, (i) {
           return Padding(
-            padding: EdgeInsets.symmetric(horizontal: 6.w),
+            padding: EdgeInsets.symmetric(horizontal: hPad),
             child: Image.asset(
               'images/time$i.png',
-              width: 48.w,
-              height: 48.w,
+              width: imgSize,
+              height: imgSize,
             ),
           );
         }),

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -252,15 +252,16 @@ class _DotIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: List.generate(total, (i) {
         return GestureDetector(
           onTap: () => onTap(i),
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
-            width: i == current ? 24.w : 8.w,
-            height: 8.h,
-            margin: EdgeInsets.only(right: 6.w),
+            width: i == current ? 20.0 : 7.0,
+            height: 7.0,
+            margin: const EdgeInsets.only(right: 5),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(4),
               color: i == current

--- a/lib/about_me.dart
+++ b/lib/about_me.dart
@@ -334,7 +334,7 @@ class _TimeSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final shortestSide = MediaQuery.of(context).size.shortestSide;
-    final imgSize = (shortestSide / 360 * 48).clamp(48.0, 96.0);
+    final imgSize = (shortestSide / 360 * 48).clamp(48.0, 130.0);
     final hPad = (shortestSide / 360 * 6).clamp(6.0, 10.0);
 
     return FittedBox(

--- a/lib/base.dart
+++ b/lib/base.dart
@@ -4,6 +4,7 @@ import 'package:gussuri/calendar.dart';
 import 'package:gussuri/component/header.dart';
 import 'package:gussuri/enums/TabItem.dart';
 import 'package:gussuri/home.dart';
+import 'package:gussuri/utils.dart';
 
 final _navigatorKeys = <TabItem, GlobalKey<NavigatorState>>{
   TabItem.home: GlobalKey<NavigatorState>(),
@@ -25,49 +26,80 @@ class Base extends HookWidget {
       currentTab.value = newTab;
     }
 
+    void onNavTap(int index) {
+      final selectedTab = TabItem.values[index];
+      if (currentTab.value == selectedTab) {
+        _navigatorKeys[selectedTab]
+            ?.currentState
+            ?.popUntil((route) => route.isFirst);
+      } else {
+        currentTab.value = selectedTab;
+        currentIndex.value = index;
+      }
+    }
+
+    final tabBody = Stack(
+      children: TabItem.values
+          .map(
+            (tabItem) => Offstage(
+              offstage: currentTab.value != tabItem,
+              child: Navigator(
+                key: _navigatorKeys[tabItem],
+                onGenerateRoute: (settings) {
+                  if (tabItem.page is Home) {
+                    return MaterialPageRoute<Widget>(
+                      builder: (context) =>
+                          Home(updateIndex: updateTab),
+                    );
+                  } else if (tabItem.page is Calendar) {
+                    return MaterialPageRoute<Widget>(
+                      builder: (context) =>
+                          Calendar(updateIndex: updateTab),
+                    );
+                  } else {
+                    return MaterialPageRoute<Widget>(
+                      builder: (context) => tabItem.page,
+                    );
+                  }
+                },
+              ),
+            ),
+          )
+          .toList(),
+    );
+
+    if (isTablet(context)) {
+      return Scaffold(
+        appBar: const Header(),
+        body: Row(
+          children: [
+            NavigationRail(
+              selectedIndex: currentIndex.value,
+              onDestinationSelected: onNavTap,
+              labelType: NavigationRailLabelType.selected,
+              indicatorColor: const Color(0xFFc5cae9),
+              destinations: TabItem.values
+                  .map(
+                    (tabItem) => NavigationRailDestination(
+                      icon: Icon(tabItem.icon),
+                      label: Text(tabItem.title(context)),
+                    ),
+                  )
+                  .toList(),
+            ),
+            const VerticalDivider(thickness: 1, width: 1),
+            Expanded(child: tabBody),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: const Header(),
-      body: Stack(
-        children: TabItem.values
-            .map(
-              (tabItem) => Offstage(
-                offstage: currentTab.value != tabItem,
-                child: Navigator(
-                  key: _navigatorKeys[tabItem],
-                  onGenerateRoute: (settings) {
-                    if(tabItem.page is Home) {
-                      return MaterialPageRoute<Widget>(
-                        builder: (context) => Home(updateIndex: updateTab),
-                      );
-                    } else if(tabItem.page is Calendar) {
-                      return MaterialPageRoute<Widget>(
-                        builder: (context) => Calendar(updateIndex: updateTab),
-                      );
-                    } else {
-                      return MaterialPageRoute<Widget>(
-                        builder: (context) => tabItem.page,
-                      );
-                    }
-                  },
-                ),
-              ),
-            )
-            .toList(),
-      ),
+      body: tabBody,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: currentIndex.value,
-        onTap: (index) {
-          final selectedTab = TabItem.values[index];
-          if (currentTab.value == selectedTab) {
-            _navigatorKeys[selectedTab]
-                ?.currentState
-                ?.popUntil((route) => route.isFirst);
-          } else {
-            // 未選択
-            currentTab.value = selectedTab;
-            currentIndex.value = index;
-          }
-        },
+        onTap: onNavTap,
         items: TabItem.values
             .map(
               (tabItem) => BottomNavigationBarItem(

--- a/lib/base.dart
+++ b/lib/base.dart
@@ -70,7 +70,7 @@ class Base extends HookWidget {
 
     if (isTablet(context)) {
       return Scaffold(
-        appBar: const Header(),
+        appBar: Header(pageTitle: currentTab.value.pageTitle(context)),
         body: Row(
           children: [
             NavigationRail(

--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gussuri/component/title_box.dart';
@@ -226,7 +227,13 @@ class _CalendarState extends State<Calendar> {
                                     builder: (context) => Input(
                                         _panelDay!,
                                         nextPage: const Calendar())),
-                              ),
+                              ).then((_) {
+                                if (mounted) {
+                                  setState(() {
+                                    _panelEvents = _getEventsForDay(_panelDay!);
+                                  });
+                                }
+                              }),
                       onEdit: (_panelDay == null || _panelEvents.isEmpty)
                           ? null
                           : () => Navigator.push(
@@ -235,7 +242,13 @@ class _CalendarState extends State<Calendar> {
                                     builder: (context) => Edit(
                                         _panelEvents.first.sleepyData,
                                         _panelEvents.first.documentId)),
-                              ),
+                              ).then((_) {
+                                if (mounted) {
+                                  setState(() {
+                                    _panelEvents = _getEventsForDay(_panelDay!);
+                                  });
+                                }
+                              }),
                     ),
                   ),
                 ],
@@ -253,10 +266,7 @@ class _CalendarState extends State<Calendar> {
             TitleBox(
                 text: AppLocalizations.of(context)?.calendar ??
                     '睡眠記録カレンダー'),
-            SizedBox(
-              height: 400,
-              child: _buildCalendar(),
-            ),
+            _buildCalendar(),
             const SizedBox(height: 8.0),
             Expanded(
                 child: Container(
@@ -287,7 +297,9 @@ class _DetailPanel extends StatelessWidget {
   String _formatTime(dynamic value) {
     try {
       DateTime dt;
-      if (value is DateTime) {
+      if (value is Timestamp) {
+        dt = value.toDate();
+      } else if (value is DateTime) {
         dt = value;
       } else {
         dt = DateTime.parse(value.toString()).toLocal();

--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -352,23 +352,74 @@ class _DetailPanel extends StatelessWidget {
     }
 
     final data = events.first.sleepyData;
+    final dysfunction = data['dysfunction'] ?? 0;
+
+    // 睡眠時間を計算
+    String sleepDuration = '--';
+    try {
+      final bed = _formatTime(data['bed_time']);
+      final getUp = _formatTime(data['get_up_time']);
+      if (bed != '--:--' && getUp != '--:--') {
+        DateTime bedDt;
+        DateTime getUpDt;
+        final raw = data['bed_time'];
+        if (raw is Timestamp) {
+          bedDt = raw.toDate();
+        } else if (raw is DateTime) {
+          bedDt = raw;
+        } else {
+          bedDt = DateTime.parse(raw.toString()).toLocal();
+        }
+        final raw2 = data['get_up_time'];
+        if (raw2 is Timestamp) {
+          getUpDt = raw2.toDate();
+        } else if (raw2 is DateTime) {
+          getUpDt = raw2;
+        } else {
+          getUpDt = DateTime.parse(raw2.toString()).toLocal();
+        }
+        var dur = getUpDt.difference(bedDt);
+        if (dur.isNegative) dur += const Duration(days: 1);
+        final h = dur.inHours;
+        final m = dur.inMinutes % 60;
+        sleepDuration = m > 0 ? '$h時間$m分' : '$h時間';
+      }
+    } catch (_) {}
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            DateFormat('yyyy/M/d').format(selectedDay!),
-            style: const TextStyle(
-                fontSize: 18, fontWeight: FontWeight.bold),
+          // 日付 + 休養スコア
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  DateFormat('yyyy/M/d').format(selectedDay!),
+                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+              ),
+              ClipOval(
+                child: Image.asset(
+                  'images/evaluation_$dysfunction.jpg',
+                  width: 48,
+                  height: 48,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${localizations.rate} $dysfunction',
+                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+              ),
+            ],
           ),
           const SizedBox(height: 16),
-          _SummaryRow(
-              label: localizations.inputTimeInBed,
-              value: _formatTime(data['bed_time'])),
-          _SummaryRow(
-              label: localizations.inputGetUpTime,
-              value: _formatTime(data['get_up_time'])),
+          _SummaryRow(label: localizations.inputTimeInBed, value: _formatTime(data['bed_time'])),
+          _SummaryRow(label: localizations.inputGetUpTime, value: _formatTime(data['get_up_time'])),
+          _SummaryRow(label: '睡眠時間', value: sleepDuration),
+          const Divider(height: 20),
           _SummaryRow(
               label: localizations.inputWakeingUp,
               value: '${data['SOL'] ?? '--'}'),

--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gussuri/component/title_box.dart';
 import 'package:gussuri/edit.dart';
+import 'package:gussuri/utils.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'input.dart';
-import 'utils.dart';
 import 'gen_l10n/app_localizations.dart';
 
 class Calendar extends StatefulWidget {
@@ -25,6 +26,10 @@ class _CalendarState extends State<Calendar> {
   Icon _leftChevron = const Icon(Icons.chevron_left);
   Color selectedColor = const Color.fromRGBO(177, 208, 255, 1);
 
+  // タブレット右パネル用
+  DateTime? _panelDay;
+  List<Event> _panelEvents = [];
+
   @override
   void initState() {
     super.initState();
@@ -40,7 +45,6 @@ class _CalendarState extends State<Calendar> {
   }
 
   List<Event> _getEventsForDay(DateTime day) {
-    // Implementation example
     return kEvents[day] ?? [];
   }
 
@@ -53,9 +57,20 @@ class _CalendarState extends State<Calendar> {
     }
     final events = _getEventsForDay(selectedDay);
 
+    if (isTablet(context)) {
+      setState(() {
+        _panelDay = selectedDay;
+        _panelEvents = events;
+      });
+      return;
+    }
+
     if (events.isEmpty) {
       Navigator.push(
-          context, MaterialPageRoute(builder: (context) => Input(selectedDay, nextPage: const Calendar())));
+          context,
+          MaterialPageRoute(
+              builder: (context) =>
+                  Input(selectedDay, nextPage: const Calendar())));
     } else {
       Navigator.push(
           context,
@@ -75,123 +90,172 @@ class _CalendarState extends State<Calendar> {
     }
   }
 
+  Widget _buildCalendar() {
+    return SizedBox(
+      height: isTablet(context) ? double.infinity : 400,
+      child: TableCalendar(
+        shouldFillViewport: true,
+        firstDay: kFirstDay,
+        lastDay: kToday,
+        focusedDay: _focusedDay,
+        headerStyle: HeaderStyle(
+          formatButtonVisible: false,
+          leftChevronIcon: _leftChevron,
+          rightChevronIcon: _rightChevron,
+          titleCentered: true,
+        ),
+        calendarStyle: const CalendarStyle(
+          outsideDaysVisible: false,
+        ),
+        calendarBuilders: CalendarBuilders(
+          defaultBuilder: (context, day, focusedDay) {
+            return const Text('');
+          },
+          outsideBuilder: (context, day, focusedDay) {
+            return const Text('');
+          },
+          todayBuilder: (context, day, focusedDay) {
+            return const Text('');
+          },
+          markerBuilder: (context, day, focusedDay) {
+            return const Text('');
+          },
+          singleMarkerBuilder: (context, day, focusedDay) {
+            return const Text('');
+          },
+          rangeHighlightBuilder: (context, day, focusedDay) {
+            final imgPath = _getImagePath(day);
+            final today = DateTime.now();
+            final todayDate =
+                DateTime(today.year, today.month, today.day);
+            final dayDate = DateTime(day.year, day.month, day.day);
+            if (dayDate.isBefore(todayDate) || dayDate == todayDate) {
+              return CustomCel(imgPath: imgPath, day: day.day);
+            }
+            return null;
+          },
+          selectedBuilder: (context, day, focusedDay) {
+            final imgPath = _getImagePath(day);
+            final imgOpacity =
+                imgPath == 'images/evaluation_default.jpg' ? 0.3 : 1.0;
+            return SizedBox(
+              width: 200,
+              height: 250,
+              child: Center(
+                child: Container(
+                  margin: const EdgeInsets.only(top: 2),
+                  decoration: BoxDecoration(
+                    color: selectedColor,
+                    borderRadius: BorderRadius.circular(14.0),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Text(
+                        '${day.day}',
+                        style: const TextStyle().copyWith(
+                            fontSize: 13.0,
+                            fontWeight: FontWeight.bold),
+                      ),
+                      Container(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: ClipOval(
+                          child: Opacity(
+                              opacity: imgOpacity,
+                              child: Image(
+                                image: AssetImage(imgPath),
+                                width: 28,
+                                height: 28,
+                              )),
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+        locale: Localizations.localeOf(context).languageCode,
+        selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+        eventLoader: _getEventsForDay,
+        onDaySelected: _onDaySelected,
+        onPageChanged: (focusedDay) {
+          context.read<CalenderState>().loadMonth(focusedDay);
+          setState(() {
+            _rightChevron = isSameMonth(kToday, focusedDay)
+                ? const Icon(Icons.chevron_right, color: Colors.grey)
+                : const Icon(Icons.chevron_right);
+            _leftChevron = isSameMonth(kFirstDay, focusedDay)
+                ? const Icon(Icons.chevron_left, color: Colors.grey)
+                : const Icon(Icons.chevron_left);
+          });
+          _focusedDay = focusedDay;
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     Provider.of<CalenderState>(context);
+
+    if (isTablet(context)) {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        body: Column(
+          children: [
+            TitleBox(
+                text: AppLocalizations.of(context)?.calendar ??
+                    '睡眠記録カレンダー'),
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: _buildCalendar()),
+                  const VerticalDivider(thickness: 1, width: 1),
+                  Expanded(
+                    child: _DetailPanel(
+                      selectedDay: _panelDay,
+                      events: _panelEvents,
+                      onRecord: _panelDay == null
+                          ? null
+                          : () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => Input(
+                                        _panelDay!,
+                                        nextPage: const Calendar())),
+                              ),
+                      onEdit: (_panelDay == null || _panelEvents.isEmpty)
+                          ? null
+                          : () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => Edit(
+                                        _panelEvents.first.sleepyData,
+                                        _panelEvents.first.documentId)),
+                              ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
         backgroundColor: Colors.white,
         body: Column(
           children: [
-            TitleBox(text: AppLocalizations.of(context)?.calendar ?? '睡眠記録カレンダー'),
+            TitleBox(
+                text: AppLocalizations.of(context)?.calendar ??
+                    '睡眠記録カレンダー'),
             SizedBox(
               height: 400,
-              child: TableCalendar(
-                shouldFillViewport: true,
-                firstDay: kFirstDay,
-                lastDay: kToday,
-                focusedDay: _focusedDay,
-                headerStyle: HeaderStyle(
-                  formatButtonVisible: false,
-                  leftChevronIcon: _leftChevron,
-                  rightChevronIcon: _rightChevron,
-                  titleCentered: true,
-                ),
-                calendarStyle: const CalendarStyle(
-                  outsideDaysVisible: false,
-                ),
-                calendarBuilders: CalendarBuilders(
-                  defaultBuilder: (context, day, focusedDay) {
-                    // NOTE: defaultの日付が出てしまうため
-                    return const Text('');
-                  },
-                  outsideBuilder: (context, day, focusedDay) {
-                    // NOTE: defaultの日付が出てしまうため
-                    return const Text('');
-                  },
-                  todayBuilder: (context, day, focusedDay) {
-                    // NOTE: defaultの日付が出てしまうため
-                    return const Text('');
-                  },
-                  markerBuilder: (context, day, focusedDay) {
-                    // NOTE: defaultの日付が出てしまうため
-                    return const Text('');
-                  },
-                  singleMarkerBuilder: (context, day, focusedDay) {
-                    // NOTE: defaultの日付が出てしまうため
-                    return const Text('');
-                  },
-                  rangeHighlightBuilder: (context, day, focusedDay) {
-                    final imgPath = _getImagePath(day);
-                    final today = DateTime.now();
-                    final todayDate =
-                        DateTime(today.year, today.month, today.day);
-                    final dayDate = DateTime(day.year, day.month, day.day);
-                    if (dayDate.isBefore(todayDate) || dayDate == todayDate) {
-                      return CustomCel(imgPath: imgPath, day: day.day);
-                    }
-                    return null;
-                  },
-                  selectedBuilder: (context, day, focusedDay) {
-                    final imgPath = _getImagePath(day);
-                    final imgOpacity =
-                        imgPath == 'images/evaluation_default.jpg' ? 0.3 : 1.0;
-                    // NOTE:選択された時だけレイアウトが違うので共通化してない
-                    return SizedBox(
-                      width: 200,
-                      height: 250,
-                      child: Center(
-                        child: Container(
-                          margin: const EdgeInsets.only(top: 2),
-                          decoration: BoxDecoration(
-                            color: selectedColor,
-                            borderRadius: BorderRadius.circular(14.0),
-                          ),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: <Widget>[
-                              Text(
-                                '${day.day}',
-                                style: const TextStyle().copyWith(
-                                    fontSize: 13.0,
-                                    fontWeight: FontWeight.bold),
-                              ),
-                              Container(
-                                padding: const EdgeInsets.only(top: 2),
-                                child: ClipOval(
-                                  child: Opacity(
-                                      opacity: imgOpacity,
-                                      child: Image(
-                                        image: AssetImage(imgPath),
-                                        width: 28,
-                                        height: 28,
-                                      )),
-                                ),
-                              )
-                            ],
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                locale: Localizations.localeOf(context).languageCode,
-                selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-                eventLoader: _getEventsForDay,
-                onDaySelected: _onDaySelected,
-                onPageChanged: (focusedDay) {
-                  context.read<CalenderState>().loadMonth(focusedDay);
-                  setState(() {
-                    _rightChevron = isSameMonth(kToday, focusedDay)
-                        ? const Icon(Icons.chevron_right, color: Colors.grey)
-                        : const Icon(Icons.chevron_right);
-                    _leftChevron = isSameMonth(kFirstDay, focusedDay)
-                        ? const Icon(Icons.chevron_left, color: Colors.grey)
-                        : const Icon(Icons.chevron_left);
-                  });
-                  _focusedDay = focusedDay;
-                },
-              ),
+              child: _buildCalendar(),
             ),
             const SizedBox(height: 8.0),
             Expanded(
@@ -202,6 +266,149 @@ class _CalendarState extends State<Calendar> {
             )),
           ],
         ));
+  }
+}
+
+// ─── 右パネル ───────────────────────────────────────────────
+
+class _DetailPanel extends StatelessWidget {
+  final DateTime? selectedDay;
+  final List<Event> events;
+  final VoidCallback? onRecord;
+  final VoidCallback? onEdit;
+
+  const _DetailPanel({
+    required this.selectedDay,
+    required this.events,
+    required this.onRecord,
+    required this.onEdit,
+  });
+
+  String _formatTime(dynamic value) {
+    try {
+      DateTime dt;
+      if (value is DateTime) {
+        dt = value;
+      } else {
+        dt = DateTime.parse(value.toString()).toLocal();
+      }
+      return DateFormat('HH:mm').format(dt);
+    } catch (_) {
+      return '--:--';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+
+    if (selectedDay == null) {
+      return Center(
+        child: Text(
+          localizations.calendarSelectDate,
+          style: const TextStyle(color: Colors.grey),
+        ),
+      );
+    }
+
+    if (events.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              localizations.calendarNoRecord,
+              style: const TextStyle(color: Colors.grey),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xffFFD069),
+                foregroundColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50)),
+                textStyle: const TextStyle(
+                    fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+              onPressed: onRecord,
+              child: Text(localizations.record),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final data = events.first.sleepyData;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            DateFormat('yyyy/M/d').format(selectedDay!),
+            style: const TextStyle(
+                fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          _SummaryRow(
+              label: localizations.inputTimeInBed,
+              value: _formatTime(data['bed_time'])),
+          _SummaryRow(
+              label: localizations.inputGetUpTime,
+              value: _formatTime(data['get_up_time'])),
+          _SummaryRow(
+              label: localizations.inputWakeingUp,
+              value: '${data['SOL'] ?? '--'}'),
+          _SummaryRow(
+              label: localizations.inputBetweenBedToSleep,
+              value: '${data['TASAFA'] ?? '--'}'),
+          _SummaryRow(
+              label: localizations.inputAwakeingAfter,
+              value: '${data['NOA'] ?? '--'}'),
+          _SummaryRow(
+              label: localizations.inputWasoLabel,
+              value: '${data['WASO'] ?? '--'}'),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xffFFD069),
+              foregroundColor: Colors.black,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(50)),
+              textStyle: const TextStyle(
+                  fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            onPressed: onEdit,
+            child: Text(localizations.edit),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _SummaryRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6.0),
+      child: Row(
+        children: [
+          Expanded(
+              child: Text(label,
+                  style: const TextStyle(color: Colors.grey, fontSize: 13))),
+          Text(value,
+              style: const TextStyle(
+                  fontWeight: FontWeight.bold, fontSize: 14)),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -150,6 +150,7 @@ class _CalendarState extends State<Calendar> {
                     borderRadius: BorderRadius.circular(14.0),
                   ),
                   child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
                       Text(

--- a/lib/component/about_me_page.dart
+++ b/lib/component/about_me_page.dart
@@ -37,15 +37,23 @@ class AboutMePage extends StatelessWidget {
         bottom: false,
         child: Column(
           children: [
-            SizedBox(height: size.height * 0.05),
-            ConstrainedBox(
-              constraints: BoxConstraints(maxHeight: size.height * 0.38),
-              child: FadeTransition(
-                opacity: fadeAnimation,
-                child: illustration,
+            Flexible(
+              flex: 2,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: size.height * 0.38,
+                    maxWidth: size.width * 0.9,
+                  ),
+                  child: FadeTransition(
+                    opacity: fadeAnimation,
+                    child: illustration,
+                  ),
+                ),
               ),
             ),
             Expanded(
+              flex: 3,
               child: SingleChildScrollView(
                 padding: EdgeInsets.fromLTRB(hPadding, 20, hPadding, 100),
                 child: SlideTransition(

--- a/lib/component/about_me_page.dart
+++ b/lib/component/about_me_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class AboutMePage extends StatelessWidget {
   final String title;
@@ -35,59 +34,58 @@ class AboutMePage extends StatelessWidget {
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 560),
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: 32.w),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Spacer(),
-                  FadeTransition(
+            child: Column(
+              children: [
+                SizedBox(height: screenHeight * 0.06),
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxHeight: screenHeight * 0.28),
+                  child: FadeTransition(
                     opacity: fadeAnimation,
+                    child: illustration,
+                  ),
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.fromLTRB(32, 20, 32, 100),
                     child: SlideTransition(
                       position: slideAnimation,
-                      child: Column(
-                        children: [
-                          ConstrainedBox(
-                            constraints: BoxConstraints(
-                              maxHeight: screenHeight * 0.28,
+                      child: FadeTransition(
+                        opacity: fadeAnimation,
+                        child: Column(
+                          children: [
+                            Text(
+                              title,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black26,
+                                    blurRadius: 6,
+                                    offset: Offset(0, 2),
+                                  ),
+                                ],
+                              ),
                             ),
-                            child: illustration,
-                          ),
-                          SizedBox(height: 32.h),
-                          Text(
-                            title,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 22.sp,
-                              fontWeight: FontWeight.bold,
-                              shadows: const [
-                                Shadow(
-                                  color: Colors.black26,
-                                  blurRadius: 6,
-                                  offset: Offset(0, 2),
-                                ),
-                              ],
+                            const SizedBox(height: 14),
+                            Text(
+                              description,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.9),
+                                fontSize: 15,
+                                height: 1.7,
+                              ),
                             ),
-                          ),
-                          SizedBox(height: 14.h),
-                          Text(
-                            description,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.9),
-                              fontSize: 14.sp,
-                              height: 1.7,
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                  // ボタンバーの高さ分の余白を確保
-                  const SizedBox(height: 96),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/component/about_me_page.dart
+++ b/lib/component/about_me_page.dart
@@ -33,12 +33,12 @@ class AboutMePage extends StatelessWidget {
         bottom: false,
         child: Center(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 560),
+            constraints: const BoxConstraints(maxWidth: 700),
             child: Column(
               children: [
-                SizedBox(height: screenHeight * 0.06),
+                SizedBox(height: screenHeight * 0.05),
                 ConstrainedBox(
-                  constraints: BoxConstraints(maxHeight: screenHeight * 0.28),
+                  constraints: BoxConstraints(maxHeight: screenHeight * 0.38),
                   child: FadeTransition(
                     opacity: fadeAnimation,
                     child: illustration,
@@ -58,7 +58,7 @@ class AboutMePage extends StatelessWidget {
                               textAlign: TextAlign.center,
                               style: const TextStyle(
                                 color: Colors.white,
-                                fontSize: 22,
+                                fontSize: 28,
                                 fontWeight: FontWeight.bold,
                                 shadows: [
                                   Shadow(
@@ -75,7 +75,7 @@ class AboutMePage extends StatelessWidget {
                               textAlign: TextAlign.center,
                               style: TextStyle(
                                 color: Colors.white.withValues(alpha: 0.9),
-                                fontSize: 15,
+                                fontSize: 17,
                                 height: 1.7,
                               ),
                             ),

--- a/lib/component/about_me_page.dart
+++ b/lib/component/about_me_page.dart
@@ -21,6 +21,7 @@ class AboutMePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -31,52 +32,63 @@ class AboutMePage extends StatelessWidget {
       ),
       child: SafeArea(
         bottom: false,
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 32.w),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Spacer(),
-              FadeTransition(
-                opacity: fadeAnimation,
-                child: SlideTransition(
-                  position: slideAnimation,
-                  child: Column(
-                    children: [
-                      illustration,
-                      SizedBox(height: 40.h),
-                      Text(
-                        title,
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 24.sp,
-                          fontWeight: FontWeight.bold,
-                          shadows: const [
-                            Shadow(
-                              color: Colors.black26,
-                              blurRadius: 6,
-                              offset: Offset(0, 2),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32.w),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Spacer(),
+                  FadeTransition(
+                    opacity: fadeAnimation,
+                    child: SlideTransition(
+                      position: slideAnimation,
+                      child: Column(
+                        children: [
+                          ConstrainedBox(
+                            constraints: BoxConstraints(
+                              maxHeight: screenHeight * 0.28,
                             ),
-                          ],
-                        ),
+                            child: illustration,
+                          ),
+                          SizedBox(height: 32.h),
+                          Text(
+                            title,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 22.sp,
+                              fontWeight: FontWeight.bold,
+                              shadows: const [
+                                Shadow(
+                                  color: Colors.black26,
+                                  blurRadius: 6,
+                                  offset: Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                          ),
+                          SizedBox(height: 14.h),
+                          Text(
+                            description,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.9),
+                              fontSize: 14.sp,
+                              height: 1.7,
+                            ),
+                          ),
+                        ],
                       ),
-                      SizedBox(height: 16.h),
-                      Text(
-                        description,
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.9),
-                          fontSize: 15.sp,
-                          height: 1.7,
-                        ),
-                      ),
-                    ],
+                    ),
                   ),
-                ),
+                  // ボタンバーの高さ分の余白を確保
+                  const SizedBox(height: 96),
+                ],
               ),
-              const Spacer(flex: 2),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/component/about_me_page.dart
+++ b/lib/component/about_me_page.dart
@@ -20,7 +20,11 @@ class AboutMePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final screenHeight = MediaQuery.of(context).size.height;
+    final size = MediaQuery.of(context).size;
+    // shortestSide でスケール。縦横回転してもフォントサイズが安定する
+    final scale = (size.shortestSide / 360).clamp(1.0, 2.2);
+    final hPadding = (size.width * 0.08).clamp(24.0, 120.0);
+
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -31,63 +35,58 @@ class AboutMePage extends StatelessWidget {
       ),
       child: SafeArea(
         bottom: false,
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 700),
-            child: Column(
-              children: [
-                SizedBox(height: screenHeight * 0.05),
-                ConstrainedBox(
-                  constraints: BoxConstraints(maxHeight: screenHeight * 0.38),
+        child: Column(
+          children: [
+            SizedBox(height: size.height * 0.05),
+            ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: size.height * 0.38),
+              child: FadeTransition(
+                opacity: fadeAnimation,
+                child: illustration,
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.fromLTRB(hPadding, 20, hPadding, 100),
+                child: SlideTransition(
+                  position: slideAnimation,
                   child: FadeTransition(
                     opacity: fadeAnimation,
-                    child: illustration,
-                  ),
-                ),
-                Expanded(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.fromLTRB(32, 20, 32, 100),
-                    child: SlideTransition(
-                      position: slideAnimation,
-                      child: FadeTransition(
-                        opacity: fadeAnimation,
-                        child: Column(
-                          children: [
-                            Text(
-                              title,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 28,
-                                fontWeight: FontWeight.bold,
-                                shadows: [
-                                  Shadow(
-                                    color: Colors.black26,
-                                    blurRadius: 6,
-                                    offset: Offset(0, 2),
-                                  ),
-                                ],
+                    child: Column(
+                      children: [
+                        Text(
+                          title,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 22.0 * scale,
+                            fontWeight: FontWeight.bold,
+                            shadows: const [
+                              Shadow(
+                                color: Colors.black26,
+                                blurRadius: 6,
+                                offset: Offset(0, 2),
                               ),
-                            ),
-                            const SizedBox(height: 14),
-                            Text(
-                              description,
-                              textAlign: TextAlign.center,
-                              style: TextStyle(
-                                color: Colors.white.withValues(alpha: 0.9),
-                                fontSize: 17,
-                                height: 1.7,
-                              ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
-                      ),
+                        SizedBox(height: 12.0 * scale),
+                        Text(
+                          description,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.9),
+                            fontSize: 15.0 * scale,
+                            height: 1.7,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ),
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/component/awake_form.dart
+++ b/lib/component/awake_form.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter/material.dart';
 import 'package:gussuri/component/image_buttons.dart';
 import '../gen_l10n/app_localizations.dart';
@@ -46,13 +45,19 @@ class AwakeFormState extends State<AwakeForm> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
+    final ss = MediaQuery.of(context).size.shortestSide;
+    final w = (20.0 * ss / 360).clamp(20.0, 24.0);
+    final h = (20.0 * ss / 360).clamp(20.0, 24.0);
+    final innerW = (10.0 * ss / 360).clamp(10.0, 12.0);
+    final listH = (40.0 * ss / 360).clamp(40.0, 48.0);
+    final sepW = (5.0 * ss / 360).clamp(5.0, 6.0);
     return Card(
-        margin: EdgeInsets.only(top: 10.h, right: 20.w, left: 20.w),
+        margin: EdgeInsets.only(top: h / 2, right: w, left: w),
         color: Colors.white.withValues(alpha: 0.8),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
         child: Column(children: [
           Padding(
-            padding: EdgeInsets.symmetric(vertical: 20.h),
+            padding: EdgeInsets.symmetric(vertical: h),
             child: Text(
               AppLocalizations.of(context)?.inputAwakeingAfter ?? '途中で目が覚めた',
               textAlign: TextAlign.center,
@@ -60,9 +65,9 @@ class AwakeFormState extends State<AwakeForm> with TickerProviderStateMixin {
             ),
           ),
           Container(
-            margin: EdgeInsets.only(right: 10.w, left: 10.w, bottom: 5.h),
+            margin: EdgeInsets.only(right: innerW, left: innerW, bottom: h / 4),
             child: SizedBox(
-              height: 40.h,
+              height: listH,
               child: ListView.separated(
                 shrinkWrap: true,
                 scrollDirection: Axis.horizontal,
@@ -94,7 +99,7 @@ class AwakeFormState extends State<AwakeForm> with TickerProviderStateMixin {
                   );
                 },
                 separatorBuilder: (context, index) {
-                  return Padding(padding: EdgeInsets.all(5.w));
+                  return Padding(padding: EdgeInsets.all(sepW));
                 },
               ),
             ),
@@ -102,7 +107,7 @@ class AwakeFormState extends State<AwakeForm> with TickerProviderStateMixin {
           Visibility(
             visible: isChecked,
             child: Padding(
-                padding: EdgeInsets.symmetric(vertical: 20.h),
+                padding: EdgeInsets.symmetric(vertical: h),
                 child: Opacity(
                   opacity: isChecked ? 1 : 0.5,
                   child: Text(

--- a/lib/component/header.dart
+++ b/lib/component/header.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class Header extends StatelessWidget implements PreferredSizeWidget {
-  const Header({super.key});
+  final String? pageTitle;
+  const Header({super.key, this.pageTitle});
 
   @override
   Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
@@ -10,10 +11,10 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return AppBar(
       backgroundColor: const Color(0xFF002153),
-      title: const Text(
-            'gussuri',
-            style: TextStyle(color: Colors.white),
-          ),
+      title: Text(
+        pageTitle ?? 'gussuri',
+        style: const TextStyle(color: Colors.white),
+      ),
       elevation: 0.0,
       automaticallyImplyLeading: false,
     );

--- a/lib/component/header.dart
+++ b/lib/component/header.dart
@@ -15,6 +15,7 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
         pageTitle ?? 'gussuri',
         style: const TextStyle(color: Colors.white),
       ),
+      centerTitle: true,
       elevation: 0.0,
       automaticallyImplyLeading: false,
     );

--- a/lib/component/input_card.dart
+++ b/lib/component/input_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class InputCard extends StatelessWidget {
   const InputCard({super.key, required this.form, required this.title});
@@ -8,14 +7,17 @@ class InputCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ss = MediaQuery.of(context).size.shortestSide;
+    final h = (20.0 * ss / 360).clamp(20.0, 24.0);
+    final w = (20.0 * ss / 360).clamp(20.0, 24.0);
     return Card(
-        margin: EdgeInsets.only(top: 10.h, right: 20.w, left: 20.w),
+        margin: EdgeInsets.only(top: h / 2, right: w, left: w),
         color: Colors.white.withValues(alpha: 0.8),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
         child: Column(children: [
           Padding(
-            padding: EdgeInsets.symmetric(vertical: 20.h),
-            child:  Text(
+            padding: EdgeInsets.symmetric(vertical: h),
+            child: Text(
               title,
               textAlign: TextAlign.center,
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),

--- a/lib/component/slide_button.dart
+++ b/lib/component/slide_button.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter/material.dart';
 import 'package:gussuri/component/input_card.dart';
 import '../gen_l10n/app_localizations.dart';
@@ -19,8 +18,7 @@ class SlideButtonState extends State<SlideButton>
   late final Function(int?) submitOnChanged;
   final ScrollController _scrollController = ScrollController();
 
-  // Must match itemExtent on the ListView
-  static double get _itemW => 56.w;
+  double _itemW = 56.0;
 
   @override
   void initState() {
@@ -68,6 +66,10 @@ class SlideButtonState extends State<SlideButton>
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
+    final shortestSide = MediaQuery.of(context).size.shortestSide;
+    _itemW = (56.0 * shortestSide / 360).clamp(56.0, 80.0);
+    final btnSize = (44.0 * shortestSide / 360).clamp(44.0, 60.0);
+    final listH = btnSize + 20;
 
     return InputCard(
       title: localizations.inputLastnight,
@@ -81,7 +83,7 @@ class SlideButtonState extends State<SlideButton>
           ),
           Expanded(
             child: SizedBox(
-              height: 70.h,
+              height: listH,
               child: ListView.builder(
                 shrinkWrap: true,
                 controller: _scrollController,
@@ -103,7 +105,7 @@ class SlideButtonState extends State<SlideButton>
                         style: ElevatedButton.styleFrom(
                           shape: const CircleBorder(),
                           backgroundColor: Colors.white,
-                          fixedSize: Size(44.w, 44.w),
+                          fixedSize: Size(btnSize, btnSize),
                           padding: EdgeInsets.zero,
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                         ),

--- a/lib/component/submit_button.dart
+++ b/lib/component/submit_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class SubmitButton extends StatelessWidget {
   final String buttonText;
@@ -9,12 +8,16 @@ class SubmitButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ss = MediaQuery.of(context).size.shortestSide;
+    final pad = (20.0 * ss / 360).clamp(20.0, 24.0);
+    final minW = (150.0 * ss / 360).clamp(150.0, 200.0);
+    final minH = (60.0 * ss / 360).clamp(60.0, 70.0);
     return Padding(
-      padding: EdgeInsets.only(right: 20.w, top: 20.h, bottom: 10.h),
+      padding: EdgeInsets.only(right: pad, top: pad, bottom: pad / 2),
       child: ElevatedButton(
           onPressed: onPressed,
           style: ElevatedButton.styleFrom(
-            minimumSize: Size(150.w, 60.h),
+            minimumSize: Size(minW, minH),
             backgroundColor: const Color(0xFFFFD069),
             foregroundColor: Colors.black,
             disabledForegroundColor: const Color(0xFF101326),

--- a/lib/component/title_box.dart
+++ b/lib/component/title_box.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gussuri/utils.dart';
 
 class TitleBox extends StatelessWidget {
   final String text;
@@ -7,10 +7,11 @@ class TitleBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (isTablet(context)) return const SizedBox.shrink();
     return Container(
       decoration: const BoxDecoration(color: Color(0xFF002153)),
       width: double.infinity,
-      padding: EdgeInsets.symmetric(vertical: 10.h),
+      padding: const EdgeInsets.symmetric(vertical: 10),
       child: Text(text,
         textAlign: TextAlign.center,
         style: const TextStyle(

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -88,6 +88,7 @@ class _EditState extends State<Edit> {
 
   Widget _buildFormItems(AppLocalizations l) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         TitleBox(text: _formattedDate),
         SlideButton(
@@ -259,7 +260,7 @@ class _EditState extends State<Edit> {
               Expanded(
                 flex: 2,
                 child: Container(
-                  color: Colors.white.withValues(alpha: 0.12),
+                  color: const Color(0xFF001637),
                   child: _buildSummaryPanel(localizations),
                 ),
               ),

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -146,8 +146,13 @@ class _EditState extends State<Edit> {
   }
 
   Widget _buildSummaryPanel(AppLocalizations l) {
-    final bed = convertDateTime(_sleepyData['bed_time']);
-    final getUp = convertDateTime(_sleepyData['get_up_time']);
+    DateTime safeConvert(dynamic v) {
+      if (v is DateTime) return v;
+      if (v is String) return DateTime.parse(v).toLocal();
+      return convertDateTime(v);
+    }
+    final bed = safeConvert(_sleepyData['bed_time']);
+    final getUp = safeConvert(_sleepyData['get_up_time']);
     var dur = getUp.difference(bed);
     if (dur.isNegative) dur += const Duration(days: 1);
     final hours = dur.inHours;
@@ -260,7 +265,7 @@ class _EditState extends State<Edit> {
               Expanded(
                 flex: 2,
                 child: Container(
-                  color: const Color(0xFF001637),
+                  color: Colors.black.withValues(alpha: 0.45),
                   child: _buildSummaryPanel(localizations),
                 ),
               ),

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/intl.dart';
 import 'package:gussuri/calendar.dart';
 import 'package:gussuri/component/TimePicker.dart';
 import 'package:gussuri/component/awake_form.dart';
@@ -79,9 +80,194 @@ class _EditState extends State<Edit> {
     _formattedDate = '${_paths[1]}年${_paths[2]}月${_paths[3]}日';
   }
 
+  void _onSubmit() {
+    _getUpTimeKey.currentState?.finalizeChanges();
+    _bedTimeKey.currentState?.finalizeChanges();
+    _updateSleepyData();
+  }
+
+  Widget _buildFormItems(AppLocalizations l) {
+    return Column(
+      children: [
+        TitleBox(text: _formattedDate),
+        SlideButton(
+          value: _sleepyData['dysfunction'],
+          onChanged: (value) => setState(() => _sleepyData['dysfunction'] = value),
+        ),
+        InputCard(
+          title: l.inputGetUpTime,
+          form: Container(
+            alignment: Alignment.center,
+            margin: const EdgeInsets.only(bottom: 10),
+            child: TimePickerWidget(
+              key: _getUpTimeKey,
+              value: convertDateTime(_sleepyData["get_up_time"]),
+              onChanged: (value) => setState(() => _sleepyData["get_up_time"] = value),
+            ),
+          ),
+        ),
+        InputCard(
+          title: l.inputWakeingUp,
+          form: ImageButton(
+            value: _sleepyData['SOL'],
+            key: const GlobalObjectKey<ImageButtonState>('__EDIT_SOL_KEY__'),
+            onChanged: (value) => setState(() => _sleepyData['SOL'] = value),
+          ),
+        ),
+        AwakeForm(
+          timesValue: _sleepyData['NOA'],
+          slideValue: _sleepyData['WASO'],
+          onChangedTimes: (value) => setState(() => _sleepyData['NOA'] = value),
+          onChangedSlide: (value) => setState(() => _sleepyData['WASO'] = value),
+        ),
+        InputCard(
+          title: l.inputBetweenBedToSleep,
+          form: ImageButton(
+            value: _sleepyData['TASAFA'],
+            key: const GlobalObjectKey<ImageButtonState>('__EDIT_TASAFA_KEY__'),
+            onChanged: (value) => setState(() => _sleepyData['TASAFA'] = value),
+          ),
+        ),
+        InputCard(
+          title: l.inputTimeInBed,
+          form: Container(
+            alignment: Alignment.center,
+            margin: const EdgeInsets.only(bottom: 10),
+            child: TimePickerWidget(
+              key: _bedTimeKey,
+              value: convertDateTime(_sleepyData["bed_time"]),
+              onChanged: (value) => setState(() => _sleepyData["bed_time"] = value),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryPanel(AppLocalizations l) {
+    final bed = convertDateTime(_sleepyData['bed_time']);
+    final getUp = convertDateTime(_sleepyData['get_up_time']);
+    var dur = getUp.difference(bed);
+    if (dur.isNegative) dur += const Duration(days: 1);
+    final hours = dur.inHours;
+    final mins = dur.inMinutes % 60;
+    final durStr = mins > 0 ? '$hours時間$mins分' : '$hours時間';
+
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+            child: Column(
+              children: [
+                ClipOval(
+                  child: Image.asset(
+                    'images/evaluation_${_sleepyData['dysfunction']}.jpg',
+                    width: 72,
+                    height: 72,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  '${l.rate} ${_sleepyData['dysfunction']}',
+                  style: const TextStyle(
+                      color: Colors.white, fontSize: 15, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 20),
+                _summaryRow('🌙', l.inputTimeInBed, DateFormat('HH:mm').format(bed)),
+                _summaryRow('☀️', l.inputGetUpTime, DateFormat('HH:mm').format(getUp)),
+                _summaryRow('💤', '睡眠時間', durStr),
+                const SizedBox(height: 8),
+                if ((_sleepyData['SOL'] ?? '') != '')
+                  _summaryRow('⏱', l.inputWakeingUp,
+                      (_sleepyData['SOL'] as String).replaceAll('\n', ' ')),
+                if (_sleepyData['NOA'] != null)
+                  _summaryRow('👁', l.inputAwakeingAfter, '${_sleepyData['NOA']}回'),
+                if ((_sleepyData['WASO'] ?? '') != '')
+                  _summaryRow('🕐', l.inputWasoLabel,
+                      (_sleepyData['WASO'] as String).replaceAll('\n', ' ')),
+                if ((_sleepyData['TASAFA'] ?? '') != '')
+                  _summaryRow('🛏', l.inputBetweenBedToSleep,
+                      (_sleepyData['TASAFA'] as String).replaceAll('\n', ' ')),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: SizedBox(
+            width: double.infinity,
+            height: 54,
+            child: ElevatedButton(
+              onPressed: _checkSubmit() ? _onSubmit : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xffFFD069),
+                foregroundColor: Colors.black,
+                disabledForegroundColor: const Color(0xFF101326),
+                disabledBackgroundColor: const Color(0xFF6D5F44),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50)),
+                textStyle: const TextStyle(
+                    fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              child: Text(l.editComplete),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _summaryRow(String emoji, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 15)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(label,
+                style: const TextStyle(color: Colors.white70, fontSize: 12)),
+          ),
+          Text(value,
+              style: const TextStyle(
+                  color: Colors.white, fontSize: 13, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
+
+    if (isTablet(context)) {
+      return Scaffold(
+        backgroundColor: Colors.transparent,
+        body: GradientBox(
+          child: Row(
+            children: [
+              Expanded(
+                flex: 3,
+                child: SingleChildScrollView(
+                  physics: const ClampingScrollPhysics(),
+                  child: _buildFormItems(localizations),
+                ),
+              ),
+              const VerticalDivider(thickness: 1, width: 1, color: Colors.white24),
+              Expanded(
+                flex: 2,
+                child: Container(
+                  color: Colors.white.withValues(alpha: 0.12),
+                  child: _buildSummaryPanel(localizations),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
         backgroundColor: Colors.transparent,
@@ -94,88 +280,13 @@ class _EditState extends State<Edit> {
               child: GradientBox(
                   child: Column(
                 children: [
-                  TitleBox(text: _formattedDate),
-                  SlideButton(
-                    value: _sleepyData['dysfunction'],
-                    onChanged: (value) {
-                      setState(() {
-                        _sleepyData['dysfunction'] = value;
-                      });
-                    },
-                  ),
-                  InputCard(
-                      title: localizations.inputGetUpTime,
-                      form: Container(
-                          alignment: Alignment.center,
-                          margin: EdgeInsets.only(bottom: 10.h),
-                          child: TimePickerWidget(
-                              key: _getUpTimeKey,
-                              value:
-                                  convertDateTime(_sleepyData["get_up_time"]),
-                              onChanged: (value) => {
-                                    setState(() {
-                                      _sleepyData["get_up_time"] = value;
-                                    })
-                                  }))),
-                  InputCard(
-                      title: localizations.inputWakeingUp,
-                      form: ImageButton(
-                          value: _sleepyData['SOL'],
-                          key: const GlobalObjectKey<ImageButtonState>('__EDIT_SOL_KEY__'),
-                          onChanged: (value) {
-                            setState(() {
-                              _sleepyData['SOL'] = value;
-                            });
-                          })),
-                  AwakeForm(
-                    timesValue: _sleepyData['NOA'],
-                    slideValue: _sleepyData['WASO'],
-                    onChangedTimes: (value) {
-                      setState(() {
-                        _sleepyData['NOA'] = value;
-                      });
-                    },
-                    onChangedSlide: (value) {
-                      setState(() {
-                        _sleepyData['WASO'] = value;
-                      });
-                    },
-                  ),
-                  InputCard(
-                      title: localizations.inputBetweenBedToSleep,
-                      form: ImageButton(
-                          value: _sleepyData['TASAFA'],
-                          key: const GlobalObjectKey<ImageButtonState>('__EDIT_TASAFA_KEY__'),
-                          onChanged: (value) {
-                            setState(() {
-                              _sleepyData['TASAFA'] = value;
-                            });
-                          })),
-                  InputCard(
-                      title: localizations.inputTimeInBed,
-                      form: Container(
-                          alignment: Alignment.center,
-                          margin: EdgeInsets.only(bottom: 10.h),
-                          child: TimePickerWidget(
-                              key: _bedTimeKey,
-                              value: convertDateTime(_sleepyData["bed_time"]),
-                              onChanged: (value) => {
-                                    setState(() {
-                                      _sleepyData["bed_time"] = value;
-                                    })
-                                  }))),
+                  _buildFormItems(localizations),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       SubmitButton(
-                        buttonText: localizations.inputComplete,
-                        onPressed: _checkSubmit()
-                            ? () {
-                                _getUpTimeKey.currentState?.finalizeChanges();
-                                _bedTimeKey.currentState?.finalizeChanges();
-                                _updateSleepyData();
-                              }
-                            : null,
+                        buttonText: localizations.editComplete,
+                        onPressed: _checkSubmit() ? _onSubmit : null,
                       )
                     ],
                   )

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -85,7 +85,10 @@ class _EditState extends State<Edit> {
 
     return Scaffold(
         backgroundColor: Colors.transparent,
-        body: Stack(children: [
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Stack(children: [
           SingleChildScrollView(
               physics: const ClampingScrollPhysics(),
               child: GradientBox(
@@ -185,6 +188,9 @@ class _EditState extends State<Edit> {
                 padding: EdgeInsets.only(left: 20.w),
                 child: Image.asset('images/baku-kun-2.png'),
               ))
-        ]));
+        ]),
+          ),
+        ),
+    );
   }
 }

--- a/lib/enums/TabItem.dart
+++ b/lib/enums/TabItem.dart
@@ -47,4 +47,17 @@ extension TabItemExtension on TabItem {
         return AppLocalizations.of(context)?.help ?? 'ヘルプ';
     }
   }
+
+  String pageTitle(BuildContext context) {
+    switch (this) {
+      case TabItem.home:
+        return AppLocalizations.of(context)?.home ?? 'ホーム';
+      case TabItem.calender:
+        return AppLocalizations.of(context)?.calender ?? '睡眠記録カレンダー';
+      case TabItem.print:
+        return AppLocalizations.of(context)?.printSleepLog ?? '睡眠記録の印刷';
+      case TabItem.help:
+        return AppLocalizations.of(context)?.help ?? 'ヘルプ';
+    }
+  }
 }

--- a/lib/help.dart
+++ b/lib/help.dart
@@ -33,7 +33,10 @@ class _HelpState extends State<Help> {
     ];
 
     return Scaffold(
-        body: Column(
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         TitleBox(text: localizations.help),
@@ -96,6 +99,9 @@ class _HelpState extends State<Help> {
           },
         )
       ],
-    ));
+            ),
+          ),
+        ),
+    );
   }
 }

--- a/lib/help.dart
+++ b/lib/help.dart
@@ -33,74 +33,81 @@ class _HelpState extends State<Help> {
     ];
 
     return Scaffold(
-        body: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 600),
-            child: Column(
+        body: Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         TitleBox(text: localizations.help),
-        ListView.builder(
-            shrinkWrap: true,
-            physics: const BouncingScrollPhysics(),
-            itemCount: listItems.length,
-            itemBuilder: (context, index) {
-              return Container(
-                  decoration: const BoxDecoration(
-                    border: Border(
-                      bottom: BorderSide(color: Color(0xFFC4C4C4)),
-                    ),
-                  ),
-                  child: ListTile(
-                    trailing: const Icon(Icons.arrow_forward_ios),
-                    title: Text(listItems[index]['title']),
-                    onTap: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => listItems[index]['link']));
-                    },
-                  ));
-            }),
-        Container(
-          padding: const EdgeInsets.all(8.0),
-          child: Text(localizations.googleFond),
-        ),
-        const Spacer(),
-        FutureBuilder<String>(
-          future: _deviceIdFuture,
-          builder: (context, snap) {
-            return SafeArea(
-              top: false,
-              child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
-              child: Row(
+        Expanded(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  Text(
-                    '${localizations.helpUserId}: ${snap.data ?? '...'}',
-                    style: const TextStyle(fontSize: 11, color: Colors.grey),
+                  ListView.builder(
+                      shrinkWrap: true,
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: listItems.length,
+                      itemBuilder: (context, index) {
+                        return Container(
+                            decoration: const BoxDecoration(
+                              border: Border(
+                                bottom: BorderSide(color: Color(0xFFC4C4C4)),
+                              ),
+                            ),
+                            child: ListTile(
+                              trailing: const Icon(Icons.arrow_forward_ios),
+                              title: Text(listItems[index]['title']),
+                              onTap: () {
+                                Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (context) => listItems[index]['link']));
+                              },
+                            ));
+                      }),
+                  Container(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(localizations.googleFond),
                   ),
-                  if (snap.hasData)
-                    GestureDetector(
-                      onTap: () {
-                        Clipboard.setData(ClipboardData(text: snap.data!));
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(localizations.helpCopied)),
-                        );
-                      },
-                      child: const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 4),
-                        child: Icon(Icons.copy, size: 14, color: Colors.grey),
-                      ),
-                    ),
+                  const Spacer(),
+                  FutureBuilder<String>(
+                    future: _deviceIdFuture,
+                    builder: (context, snap) {
+                      return SafeArea(
+                        top: false,
+                        child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
+                        child: Row(
+                          children: [
+                            Text(
+                              '${localizations.helpUserId}: ${snap.data ?? '...'}',
+                              style: const TextStyle(fontSize: 11, color: Colors.grey),
+                            ),
+                            if (snap.hasData)
+                              GestureDetector(
+                                onTap: () {
+                                  Clipboard.setData(ClipboardData(text: snap.data!));
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text(localizations.helpCopied)),
+                                  );
+                                },
+                                child: const Padding(
+                                  padding: EdgeInsets.symmetric(horizontal: 4),
+                                  child: Icon(Icons.copy, size: 14, color: Colors.grey),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ));
+                    },
+                  ),
                 ],
               ),
-            ));
-          },
-        )
-      ],
             ),
           ),
+        ),
+      ],
         ),
     );
   }

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -72,6 +72,136 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
+    if (isTablet(context)) {
+      return Scaffold(
+        backgroundColor: Colors.transparent,
+        body: GradientBox(
+          child: Row(
+            children: [
+              // 左カラム：バク君 + チャレンジTips
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.all(32),
+                        child: Center(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.9),
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                            padding: const EdgeInsets.all(20),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  localizations.challenge,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                const SizedBox(height: 10),
+                                Text(
+                                  AppLocalizations.of(context)?.challengeFirst ?? _tips,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Image.asset('images/baku-kun-1.png'),
+                  ],
+                ),
+              ),
+              // 右カラム：ボタン
+              Expanded(
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        _checkLastNightSleep == true
+                            ? Text(
+                                localizations.recordComplete,
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 18,
+                                ),
+                                textAlign: TextAlign.center,
+                              )
+                            : SizedBox(
+                                width: double.infinity,
+                                height: 72,
+                                child: ElevatedButton(
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: const Color(0xffFFD069),
+                                    foregroundColor: Colors.black,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(50),
+                                    ),
+                                    textStyle: const TextStyle(
+                                      fontSize: 26,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  onPressed: _checkLastNightSleep == false
+                                      ? () {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (context) => Input(
+                                                DateTime.now(),
+                                                nextPage: Home(
+                                                  updateIndex: widget.updateIndex,
+                                                ),
+                                              ),
+                                            ),
+                                          );
+                                        }
+                                      : null,
+                                  child: Text(localizations.record),
+                                ),
+                              ),
+                        const SizedBox(height: 20),
+                        SizedBox(
+                          width: double.infinity,
+                          height: 52,
+                          child: ElevatedButton.icon(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.white,
+                              foregroundColor: Colors.black,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(40),
+                              ),
+                              textStyle: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            onPressed: () {
+                              widget.updateIndex?.call(1, TabItem.calender);
+                            },
+                            icon: const Icon(Icons.calendar_month),
+                            label: Text(localizations.calendar),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: Center(

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -78,44 +78,43 @@ class _HomeState extends State<Home> {
         body: GradientBox(
           child: Row(
             children: [
-              // 左カラム：バク君 + チャレンジTips
+              // 左カラム：チャレンジTips + バク君
               Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.all(32),
-                        child: Center(
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.9),
-                              borderRadius: BorderRadius.circular(20),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(32, 32, 32, 0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Container(
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.9),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        padding: const EdgeInsets.all(20),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              localizations.challenge,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
-                            padding: const EdgeInsets.all(20),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  localizations.challenge,
-                                  style: const TextStyle(
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                                const SizedBox(height: 10),
-                                Text(
-                                  AppLocalizations.of(context)?.challengeFirst ?? _tips,
-                                ),
-                              ],
+                            const SizedBox(height: 10),
+                            Text(
+                              AppLocalizations.of(context)?.challengeFirst ?? _tips,
                             ),
-                          ),
+                          ],
                         ),
                       ),
-                    ),
-                    Image.asset('images/baku-kun-1.png'),
-                  ],
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Image.asset('images/baku-kun-1.png'),
+                      ),
+                    ],
+                  ),
                 ),
               ),
               // 右カラム：ボタン

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -74,8 +74,11 @@ class _HomeState extends State<Home> {
 
     return Scaffold(
       backgroundColor: Colors.transparent,
-      body: GradientBox(
-        child: Column(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: GradientBox(
+            child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Expanded(
@@ -155,6 +158,8 @@ class _HomeState extends State<Home> {
               child: Image.asset('images/baku-kun-1.png'),
             )
           ],
+        ),
+          ),
         ),
       ),
     );

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -76,11 +76,13 @@ class _InputState extends State<Input> {
 
   Future<void> _createSleepyData() async {
     final deviceId = await DeviceData.getDeviceUniqueId();
-    final ref = FirebaseFirestore.instance
+    final yearRef = FirebaseFirestore.instance
         .collection(deviceId)
-        .doc(_targetDays[0])
+        .doc(_targetDays[0]);
+    final ref = yearRef
         .collection(_targetDays[1])
         .doc(_targetDays[2]);
+    await yearRef.set({'year': int.parse(_targetDays[0])}, SetOptions(merge: true));
     await ref.set(_sleepyData);
     if (!mounted) return;
     Provider.of<CalenderState>(context, listen: false)

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -163,9 +163,14 @@ class _InputState extends State<Input> {
     );
   }
 
+  DateTime _toDateTime(dynamic value) {
+    if (value is DateTime) return value;
+    return DateTime.parse(value.toString()).toLocal();
+  }
+
   Widget _buildSummaryPanel(AppLocalizations l) {
-    final bed = _sleepyData['bed_time'] as DateTime;
-    final getUp = _sleepyData['get_up_time'] as DateTime;
+    final bed = _toDateTime(_sleepyData['bed_time']);
+    final getUp = _toDateTime(_sleepyData['get_up_time']);
     var dur = getUp.difference(bed);
     if (dur.isNegative) dur += const Duration(days: 1);
     final hours = dur.inHours;
@@ -279,7 +284,7 @@ class _InputState extends State<Input> {
               Expanded(
                 flex: 2,
                 child: Container(
-                  color: const Color(0xFF001637),
+                  color: Colors.black.withValues(alpha: 0.45),
                   child: _buildSummaryPanel(localizations),
                 ),
               ),

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -100,9 +100,193 @@ class _InputState extends State<Input> {
   final imageBoxKeySecond =
       const GlobalObjectKey<ImageButtonState>('__IMAGE_BOX_KEY2__');
 
+  void _onSubmit() {
+    timePickerKey.currentState?.finalizeChanges();
+    timePickerKeySecond.currentState?.finalizeChanges();
+    _createSleepyData();
+  }
+
+  Widget _buildFormItems(AppLocalizations l) {
+    return Column(
+      children: [
+        TitleBox(text: formattedDate),
+        SlideButton(
+          value: _sleepyData['dysfunction'],
+          onChanged: (value) => setState(() => _sleepyData['dysfunction'] = value),
+        ),
+        InputCard(
+          title: l.inputGetUpTime,
+          form: Container(
+            alignment: Alignment.center,
+            margin: const EdgeInsets.only(bottom: 10),
+            child: TimePickerWidget(
+              key: timePickerKey,
+              value: DateTime(widget.selectedDay.year, widget.selectedDay.month,
+                  widget.selectedDay.day, 9, 0).toLocal(),
+              onChanged: (value) => setState(() => _sleepyData["get_up_time"] = value),
+            ),
+          ),
+        ),
+        InputCard(
+          title: l.inputWakeingUp,
+          form: ImageButton(
+            key: imageBoxKey,
+            onChanged: (value) => setState(() => _sleepyData['SOL'] = value),
+          ),
+        ),
+        AwakeForm(
+          onChangedTimes: (value) => setState(() => _sleepyData['NOA'] = value),
+          onChangedSlide: (value) => setState(() => _sleepyData['WASO'] = value),
+        ),
+        InputCard(
+          title: l.inputBetweenBedToSleep,
+          form: ImageButton(
+            key: imageBoxKeySecond,
+            onChanged: (value) => setState(() => _sleepyData['TASAFA'] = value),
+          ),
+        ),
+        InputCard(
+          title: l.inputTimeInBed,
+          form: Container(
+            alignment: Alignment.center,
+            margin: const EdgeInsets.only(bottom: 10),
+            child: TimePickerWidget(
+              key: timePickerKeySecond,
+              value: DateTime(widget.selectedDay.year, widget.selectedDay.month,
+                  widget.selectedDay.day, 22, 0).toLocal(),
+              onChanged: (value) => setState(() => _sleepyData["bed_time"] = value),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryPanel(AppLocalizations l) {
+    final bed = _sleepyData['bed_time'] as DateTime;
+    final getUp = _sleepyData['get_up_time'] as DateTime;
+    var dur = getUp.difference(bed);
+    if (dur.isNegative) dur += const Duration(days: 1);
+    final hours = dur.inHours;
+    final mins = dur.inMinutes % 60;
+    final durStr = mins > 0 ? '$hours時間$mins分' : '$hours時間';
+
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+            child: Column(
+              children: [
+                ClipOval(
+                  child: Image.asset(
+                    'images/evaluation_${_sleepyData['dysfunction']}.jpg',
+                    width: 72,
+                    height: 72,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  '${l.rate} ${_sleepyData['dysfunction']}',
+                  style: const TextStyle(
+                    color: Colors.white, fontSize: 15, fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                _summaryRow('🌙', l.inputTimeInBed, DateFormat('HH:mm').format(bed)),
+                _summaryRow('☀️', l.inputGetUpTime, DateFormat('HH:mm').format(getUp)),
+                _summaryRow('💤', '睡眠時間', durStr),
+                const SizedBox(height: 8),
+                if ((_sleepyData['SOL'] ?? '') != '')
+                  _summaryRow('⏱', l.inputWakeingUp,
+                      (_sleepyData['SOL'] as String).replaceAll('\n', ' ')),
+                if (_sleepyData['NOA'] != null)
+                  _summaryRow('👁', l.inputAwakeingAfter, '${_sleepyData['NOA']}回'),
+                if ((_sleepyData['WASO'] ?? '') != '')
+                  _summaryRow('🕐', l.inputWasoLabel,
+                      (_sleepyData['WASO'] as String).replaceAll('\n', ' ')),
+                if ((_sleepyData['TASAFA'] ?? '') != '')
+                  _summaryRow('🛏', l.inputBetweenBedToSleep,
+                      (_sleepyData['TASAFA'] as String).replaceAll('\n', ' ')),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: SizedBox(
+            width: double.infinity,
+            height: 54,
+            child: ElevatedButton(
+              onPressed: _checkSubmit() ? _onSubmit : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xffFFD069),
+                foregroundColor: Colors.black,
+                disabledForegroundColor: const Color(0xFF101326),
+                disabledBackgroundColor: const Color(0xFF6D5F44),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50)),
+                textStyle: const TextStyle(
+                    fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              child: Text(l.inputComplete),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _summaryRow(String emoji, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 15)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(label,
+                style: const TextStyle(color: Colors.white70, fontSize: 12)),
+          ),
+          Text(value,
+              style: const TextStyle(
+                  color: Colors.white, fontSize: 13, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
+
+    if (isTablet(context)) {
+      return Scaffold(
+        backgroundColor: Colors.transparent,
+        body: GradientBox(
+          child: Row(
+            children: [
+              Expanded(
+                flex: 3,
+                child: SingleChildScrollView(
+                  physics: const ClampingScrollPhysics(),
+                  child: _buildFormItems(localizations),
+                ),
+              ),
+              const VerticalDivider(thickness: 1, width: 1, color: Colors.white24),
+              Expanded(
+                flex: 2,
+                child: Container(
+                  color: Colors.white.withValues(alpha: 0.12),
+                  child: _buildSummaryPanel(localizations),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
         backgroundColor: Colors.transparent,
@@ -115,93 +299,13 @@ class _InputState extends State<Input> {
               child: GradientBox(
                   child: Column(
                 children: [
-                  TitleBox(text: formattedDate),
-                  SlideButton(
-                    value: _sleepyData['dysfunction'],
-                    onChanged: (value) {
-                      setState(() {
-                        _sleepyData['dysfunction'] = value;
-                      });
-                    },
-                  ),
-                  InputCard(
-                      title: localizations.inputGetUpTime,
-                      form: Container(
-                          alignment: Alignment.center,
-                          margin: EdgeInsets.only(bottom: 10.h),
-                          child: TimePickerWidget(
-                              key: timePickerKey,
-                              value: DateTime(
-                                  widget.selectedDay.year,
-                                  widget.selectedDay.month,
-                                  widget.selectedDay.day,
-                                  9,
-                                  0).toLocal(),
-                              onChanged: (value) => {
-                                    setState(() {
-                                      _sleepyData["get_up_time"] = value;
-                                    })
-                                  }))),
-                  InputCard(
-                      title: localizations.inputWakeingUp,
-                      form: ImageButton(
-                          key: imageBoxKey,
-                          onChanged: (value) {
-                            setState(() {
-                              _sleepyData['SOL'] = value;
-                            });
-                          })),
-                  AwakeForm(
-                    onChangedTimes: (value) {
-                      setState(() {
-                        _sleepyData['NOA'] = value;
-                      });
-                    },
-                    onChangedSlide: (value) {
-                      setState(() {
-                        _sleepyData['WASO'] = value;
-                      });
-                    },
-                  ),
-                  InputCard(
-                      title: localizations.inputBetweenBedToSleep,
-                      form: ImageButton(
-                          key: imageBoxKeySecond,
-                          onChanged: (value) {
-                            setState(() {
-                              _sleepyData['TASAFA'] = value;
-                            });
-                          })),
-                  InputCard(
-                      title: localizations.inputTimeInBed,
-                      form: Container(
-                          alignment: Alignment.center,
-                          margin: EdgeInsets.only(bottom: 10.h),
-                          child: TimePickerWidget(
-                              key: timePickerKeySecond,
-                              value: DateTime(
-                                  widget.selectedDay.year,
-                                  widget.selectedDay.month,
-                                  widget.selectedDay.day,
-                                  22,
-                                  0).toLocal(),
-                              onChanged: (value) => {
-                                    setState(() {
-                                      _sleepyData["bed_time"] = value;
-                                    })
-                                  }))),
+                  _buildFormItems(localizations),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       SubmitButton(
                         buttonText: localizations.inputComplete,
-                        onPressed: _checkSubmit()
-                            ? () {
-                                  timePickerKey.currentState?.finalizeChanges();
-                                  timePickerKeySecond.currentState?.finalizeChanges();
-                                _createSleepyData();
-                              }
-                            : null,
+                        onPressed: _checkSubmit() ? _onSubmit : null,
                       )
                     ],
                   )

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -108,6 +108,7 @@ class _InputState extends State<Input> {
 
   Widget _buildFormItems(AppLocalizations l) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         TitleBox(text: formattedDate),
         SlideButton(
@@ -278,7 +279,7 @@ class _InputState extends State<Input> {
               Expanded(
                 flex: 2,
                 child: Container(
-                  color: Colors.white.withValues(alpha: 0.12),
+                  color: const Color(0xFF001637),
                   child: _buildSummaryPanel(localizations),
                 ),
               ),

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -106,7 +106,10 @@ class _InputState extends State<Input> {
 
     return Scaffold(
         backgroundColor: Colors.transparent,
-        body: Stack(children: [
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Stack(children: [
           SingleChildScrollView(
               physics: const ClampingScrollPhysics(),
               child: GradientBox(
@@ -211,6 +214,9 @@ class _InputState extends State<Input> {
                 padding: EdgeInsets.only(left: 20.w),
                 child: Image.asset('images/baku-kun-2.png'),
               ))
-        ]));
+        ]),
+          ),
+        ),
+    );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -58,5 +58,9 @@
   "aboutMePage8Title": "Export your data",
   "aboutMePage8Body": "From the Export tab, you can export your sleep records for a selected period as a CSV file.",
   "aboutMeNext": "Next",
-  "aboutMeDone": "Get Started"
+  "aboutMeDone": "Get Started",
+  "calendarSelectDate": "Select a date",
+  "calendarNoRecord": "No record for this day",
+  "edit": "Edit",
+  "inputWasoLabel": "Total wake time"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -58,5 +58,9 @@
   "aboutMePage8Title": "データをエクスポートしよう",
   "aboutMePage8Body": "印刷タブから、指定した期間の睡眠記録をCSVファイルとして書き出すことができます。",
   "aboutMeNext": "次へ",
-  "aboutMeDone": "はじめる"
+  "aboutMeDone": "はじめる",
+  "calendarSelectDate": "日付を選んでください",
+  "calendarNoRecord": "この日は未記録です",
+  "edit": "編集",
+  "inputWasoLabel": "中途覚醒の合計時間"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -58,5 +58,9 @@
   "aboutMePage8Title": "데이터를 내보내세요",
   "aboutMePage8Body": "인쇄 탭에서 지정한 기간의 수면 기록을 CSV 파일로 내보낼 수 있습니다.",
   "aboutMeNext": "다음",
-  "aboutMeDone": "시작하기"
+  "aboutMeDone": "시작하기",
+  "calendarSelectDate": "날짜를 선택하세요",
+  "calendarNoRecord": "이 날의 기록이 없습니다",
+  "edit": "편집",
+  "inputWasoLabel": "중간 각성 합계 시간"
 }

--- a/lib/l10n/app_tw.arb
+++ b/lib/l10n/app_tw.arb
@@ -58,5 +58,9 @@
   "aboutMePage8Title": "匯出您的資料",
   "aboutMePage8Body": "在匯出紀錄分頁中，可以將指定期間的睡眠紀錄匯出為 CSV 檔案。",
   "aboutMeNext": "下一步",
-  "aboutMeDone": "開始使用"
+  "aboutMeDone": "開始使用",
+  "calendarSelectDate": "請選擇日期",
+  "calendarNoRecord": "此日無記錄",
+  "edit": "編輯",
+  "inputWasoLabel": "中途覺醒合計時間"
 }

--- a/lib/print.dart
+++ b/lib/print.dart
@@ -185,12 +185,15 @@ class _PrintState extends State<Print> {
     final localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
-        body: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 600),
-            child: Column(
+        body: Column(
       children: [
         TitleBox(text: localizations.printSleepLog),
+        Expanded(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: Column(
+        children: [
         Align(
           alignment: Alignment.centerLeft,
           child: Padding(
@@ -280,9 +283,11 @@ class _PrintState extends State<Print> {
           ],
         )
       ],
+              ),
             ),
           ),
         ),
-    );
+      ],
+    ));
   }
 }

--- a/lib/print.dart
+++ b/lib/print.dart
@@ -185,7 +185,10 @@ class _PrintState extends State<Print> {
     final localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
-        body: Column(
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: Column(
       children: [
         TitleBox(text: localizations.printSleepLog),
         Align(
@@ -277,6 +280,9 @@ class _PrintState extends State<Print> {
           ],
         )
       ],
-    ));
+            ),
+          ),
+        ),
+    );
   }
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -36,6 +36,7 @@ Map<DateTime, List<Event>> kEvents = <DateTime, List<Event>>{};
 
 class CalenderState with ChangeNotifier {
   final _loadedMonths = <String>{};
+  final _migratedYears = <String>{};
   Future<void>? _initialFuture;
 
   /// 起動時：前月・当月の2ヶ月だけ取得
@@ -63,6 +64,19 @@ class CalenderState with ChangeNotifier {
     if (toFetch.isEmpty) return;
 
     final deviceId = await DeviceData.getDeviceUniqueId();
+
+    // 年ドキュメントを明示化（初回アクセス時のみ1回書き込み）
+    final years = toFetch.map((d) => '${d.year}').toSet();
+    for (final year in years) {
+      if (!_migratedYears.contains(year)) {
+        _migratedYears.add(year);
+        FirebaseFirestore.instance
+            .collection(deviceId)
+            .doc(year)
+            .set({'year': int.parse(year)}, SetOptions(merge: true));
+      }
+    }
+
     final snaps = await Future.wait(
       toFetch.map((date) => FirebaseFirestore.instance
           .collection(deviceId)

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -14,6 +14,9 @@ bool isSameMonth(DateTime? a, DateTime? b) {
   return a.year == b.year && a.month == b.month;
 }
 
+bool isTablet(BuildContext context) =>
+    MediaQuery.of(context).size.width >= 600;
+
 class Event {
   Map<String, dynamic> sleepyData = {
     "bed_time": DateTime.now(),


### PR DESCRIPTION
## Summary

- NavigationRail をタブレット（≥600dp）で表示、スマホは従来の BottomNavigationBar を維持
- カレンダー画面をタブレットで左右分割（左: カレンダー、右: 睡眠記録サマリー＋編集ボタン）
- 入力・編集画面をタブレットで左右分割（左: フォーム、右: リアルタイムサマリー＋完了ボタン）
- 各画面のコンテンツを最大幅 600dp に制限してスマホと同じ操作感を維持
- オンボーディング画面を `shortestSide` 基準の動的フォントスケーリングに対応
- AppBar にタブのページタイトルを表示（タブレット時は TitleBox を非表示）
- ホーム画面をタブレットで 2 カラムレイアウト（左: バク君＋チャレンジ Tips、右: ボタン）
- `TARGETED_DEVICE_FAMILY = "1,2"` に統一して iPad ネイティブ全画面表示を有効化
- Android スプラッシュスクリーンをブランドカラーに変更

## Test plan

- [x] Android エミュレータ（スマホ）で全画面正常動作を確認
- [x] iOS シミュレータ（iPad Air 13-inch M4、iOS 26.5）でタブレット UI を確認
- [x] NavigationRail のタブ切り替え・同タブタップで root pop が動作する
- [x] カレンダー右パネル: 未選択 / 記録なし / 記録あり の 3 状態が正しく表示される
- [ ] 入力フォーム: 時間変更後もサマリーパネルがクラッシュしない（Timestamp/String/DateTime 対応済み）
- [ ] オンボーディングが縦横両方向でオーバーフローしない
- [ ] CI（Android build + Firebase App Distribution）が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)