### PR TITLE
fix: 評価ラベルの表示をスライダーUIに合わせる

### DIFF
--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -411,7 +411,7 @@ class _DetailPanel extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                '${localizations.rate} $dysfunction',
+                '${localizations.rate} ${10 - (dysfunction as int)}',
                 style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
               ),
             ],

--- a/lib/edit.dart
+++ b/lib/edit.dart
@@ -176,7 +176,7 @@ class _EditState extends State<Edit> {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  '${l.rate} ${_sleepyData['dysfunction']}',
+                  '${l.rate} ${10 - (_sleepyData['dysfunction'] as int)}',
                   style: const TextStyle(
                       color: Colors.white, fontSize: 15, fontWeight: FontWeight.bold),
                 ),

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -196,7 +196,7 @@ class _InputState extends State<Input> {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  '${l.rate} ${_sleepyData['dysfunction']}',
+                  '${l.rate} ${10 - (_sleepyData['dysfunction'] as int)}',
                   style: const TextStyle(
                     color: Colors.white, fontSize: 15, fontWeight: FontWeight.bold,
                   ),


### PR DESCRIPTION
## Summary

- スライダーで「評価 8」を選択してもサマリーパネルに「評価 2」と表示されるバグを修正
- 原因: サマリーパネルが Firestore の保存値（`dysfunction`）をそのままラベルとして表示していたため
- `evaluation_0.jpg` = 最も良い睡眠（dysfunction=0 = よく眠れた）という設計において、スライダーのラベルと保存値は意図的に逆転している（`label = 10 - dysfunction`）
- 表示時に `10 - dysfunction` に変換することでスライダー表示と一致させる

## 変更ファイル

- `lib/input.dart` — 入力サマリーパネルの評価ラベル修正
- `lib/edit.dart` — 編集サマリーパネルの評価ラベル修正
- `lib/calendar.dart` — カレンダー詳細パネルの評価ラベル修正

※ 顔画像（`evaluation_${dysfunction}.jpg`）は元から正しいため変更なし

## Test plan

- [ ] 入力フォームで「評価 8」を選択 → サマリーパネルに「評価 8」と表示されることを確認
- [ ] 編集フォームで評価を変更 → サマリーパネルの表示が一致することを確認
- [ ] カレンダーで日付をタップ → 詳細パネルの評価ラベルがスライダーで選んだ値と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)